### PR TITLE
Finish Title issues

### DIFF
--- a/app/controllers/uploads.js
+++ b/app/controllers/uploads.js
@@ -49,7 +49,7 @@ const create = (req, res, next) => {
 
   const file = {
     path: req.file.path,
-    title: req.file.originalname,
+    title: req.body.image.title,
     originalname: req.file.originalname,
     mimetype: req.file.mimetype
   }

--- a/app/controllers/uploads.js
+++ b/app/controllers/uploads.js
@@ -46,10 +46,12 @@ const create = (req, res, next) => {
   console.log('req.body is', req.body)
   // next()
   const tags = JSON.parse(req.body.image.tags)
-
+  const title = req.body.image.title.trim() || req.file.originalname
+  console.log(title)
+  console.log(req.file.originalname)
   const file = {
     path: req.file.path,
-    title: req.body.image.title,
+    title: title,
     originalname: req.file.originalname,
     mimetype: req.file.mimetype
   }

--- a/app/models/upload.js
+++ b/app/models/upload.js
@@ -9,7 +9,8 @@ const uploadSchema = new mongoose.Schema({
   },
   title: {
     type: String,
-    required: true
+    required: true,
+    maxlength: [140, 'Title cannot exceed 140 characters']
   },
   tags: {
     type: Array,


### PR DESCRIPTION
1. Sets maxlength to 140 characters. Titles longer than 140 characters will error out with 500 HTML error. Front end will need to handle this error/put in front end validation to cap the length at 140.

2. Defaults `title` to the original name of the file when no `title` is sent. This function also strips padded and trailing spaces.