### PR TITLE
Adds edit to remove trailing/leading spaces from title

### DIFF
--- a/app/controllers/uploads.js
+++ b/app/controllers/uploads.js
@@ -103,7 +103,14 @@ const create = (req, res, next) => {
 const update = (req, res, next) => {
   delete req.body._owner  // disallow owner reassignment.
   delete req.body.url // disallow url reassignment
-  req.upload.update(req.body.upload)
+
+  //  remove leading and trailing spaces from title
+  // we don't want to store a title that has only spaces
+  const file = req.body.upload
+  file.title = file.title.trim()
+
+  console.log(file)
+  req.upload.update(file, {runValidators: true})
     .then(() => res.sendStatus(204))
     .catch(next)
 }


### PR DESCRIPTION
-we don't want to store a title that has only spaces or any leading
or trailing spaces on it. The code removes those.
-added option to run schema validation on the update. without this
option, no validation would be done.