### PR TITLE
Rerouted script start to ./bin/express

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "ga-wdi-boston.express-multer-upload-api",
+  "name": "all-the-things-api",
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "start": "grunt server"
+    "start": "./bin/express server"
   },
   "engines": {
     "node": "4.6.2"


### PR DESCRIPTION
Start script referenced in multer template was grunt server.
In express-api template, start script is ./bin/express server.
Renamed app in package.json.